### PR TITLE
ci: don't run pages workflow on PR

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
We shouldn't run the github pages workflow on a PR